### PR TITLE
Add ForwardDiff differentiation tooling from EquivariantTensors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "DecoratedParticles"
 uuid = "023d0394-cb16-4d2d-a5c7-724bed42bbb6"
 authors = ["Christoph Ortner <christophortner0@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
@@ -20,6 +21,7 @@ AtomsBaseExt = "AtomsBase"
 [compat]
 AtomsBase = "0.5"
 ChainRulesCore = "1"
+ForwardDiff = "0.10, 1"
 LinearAlgebra = "1.11"
 NamedTupleTools = "0.14"
 PeriodicTable = "1"

--- a/src/DecoratedParticles.jl
+++ b/src/DecoratedParticles.jl
@@ -1,7 +1,10 @@
 module DecoratedParticles
 
-# core of the package : manipulating particle states 
+# core of the package : manipulating particle states
 include("states.jl")
+
+# ForwardDiff differentiation w.r.t. states and NamedTuples
+include("differentiation.jl")
 
 include("show.jl")
 

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -1,0 +1,236 @@
+#
+# Differentiation tooling for NamedTuples and XStates: ForwardDiff
+# gradients with respect to the continuous variables stored in a
+# NamedTuple or XState.
+# (Moved here from EquivariantTensors.jl, src/transforms/diffnt.jl.)
+#
+
+using ForwardDiff: ForwardDiff, Dual
+using StaticArrays
+
+export grad_fd
+
+_iscts(::Any) = false
+_iscts(::Type{T}) where {T <: AbstractFloat} = true
+_iscts(::Type{Dual{T1, T2, T3}}) where {T1, T2, T3} = _iscts(T2)
+_iscts(T::Type{<: SArray}) = _iscts(eltype(T))
+
+
+"""
+   _ctsnt(x::NamedTuple)
+
+From a `nt::NamedTuple` extract only the continuous variables and return
+a new NamedTuple with those variables.
+"""
+@generated function _ctsnt(x::NamedTuple)
+   SYMS = fieldnames(x)
+   TT = fieldtypes(x)
+
+   code = "(; "
+   for (sym, T) in zip(SYMS, TT)
+      if _iscts(T)
+         code *= "$sym = x.$sym,"
+      end
+   end
+   code *= ")"
+   return quote
+      $(Meta.parse(code))
+   end
+end
+
+"""
+   _replace(x::NamedTuple, v::NamedTuple)
+
+Assuming that `fieldnames(v)` is a subset of `fieldnames(x)`, this constructs
+a new `NamedTuple` `y` with the same fields as `x`, but with the values of `v` replacing
+the values of `x` for the fields that are present in `v`.
+"""
+@generated function _replace(x::NamedTuple, v::NamedTuple)
+   SYMSX = fieldnames(x)
+   SYMSV = fieldnames(v)
+
+   code = "(; "
+   for sym in SYMSX
+      if sym in SYMSV
+         code *= "$sym = v.$sym,"
+      else
+         code *= "$sym = x.$sym,"
+      end
+   end
+   code *= ")"
+   return quote
+      $(Meta.parse(code))
+   end
+end
+
+"""
+   svector_type(v::NamedTuple)
+
+Assuming that all fields of `v` are either of type `T` or of type `SVector{N, T}`,
+this generates a type `SVector{N, T}` where `N` is the total number of elements
+and `T` is the unique type of the elements. If there are multiple types, it raises an error.
+"""
+@generated function svector_type(v::NamedTuple)
+   TT = fieldtypes(v)
+
+   _tfl(::Any) = Any
+   _tfl(::Type{T}) where {T <: Number} = T
+   _tfl(::Type{SVector{N, T}}) where {N, T <: Number} = T
+   T = unique(_tfl(T) for T in TT)
+
+   if length(T) > 1
+      ex = :( error("only one float type allowed") )
+   else
+
+      _len(::Type{T}) where {T <: AbstractFloat} = 1
+      _len(::Type{SVector{N, T}}) where {N, T <: AbstractFloat} = N
+
+      T = first(T)  # the only type
+      len = sum(_len, TT)
+      ex = Meta.parse("SVector{$len, $T}")
+   end
+
+   return quote
+      $(ex)
+   end
+end
+
+"""
+   _nt2svec(x::NamedTuple)
+
+Converts a `NamedTuple` `x` into a `SVector` of the type generated
+by `svector_type(x)`, i.e. flattening the data stored in `x` into a single vector.
+"""
+@generated function _nt2svec(x::TX)  where {TX <: NamedTuple}
+   SYMS = fieldnames(x)
+   TT = fieldtypes(x)
+   __length(x) = length(x)
+   __length(::Type{T}) where {T <: Number} = 1
+   __length(::Type{SVector{N, T}}) where {N, T <: Number} = N
+
+   idx = 1
+   code = "SA["
+   for (T, sym) in zip(TT, SYMS)
+      for i = 1:__length(T)
+         code *= "x.$sym[$i], "
+      end
+   end
+   code *= "]"
+   return quote
+      $(Meta.parse(code))
+   end
+end
+
+# NOTE:
+#   it is very odd - this should work fine with reinterpret:
+#      _nt2svec(x::NamedTuple) = reinterpret(svector_type(x), x)
+#   but that is causing problems with Kernelabstractions.
+#   The manual implementation above seems to work fine.
+
+
+"""
+   _svec2nt(v::SVector, x::NamedTuple)
+
+Converts a `SVector` `v` into a `NamedTuple` with the same fields as `x`,
+where each field is filled with the corresponding elements from `v`. The
+NamedTuple `x` acts as a "blueprint" for the structure of the output NamedTuple,
+specifying the field names and the length of each field. The SVector `v`
+provides the data and the data type.
+"""
+@generated function _svec2nt(v::SVector, x::NamedTuple)
+   SYMS = fieldnames(x)
+   TT = fieldtypes(x)
+
+   _len(::Type{T}) where {T <: Number} = 1
+   _len(::Type{SVector{N, T}}) where {N, T <: Number} = N
+
+   i0 = Int[]
+   idx = 1
+   for T in TT
+      push!(i0, idx)
+      idx += _len(T)
+   end
+   push!(i0, idx)
+
+   # indexing into v::SVector
+   inds = []
+   for i = 1:length(TT)
+      rg = i0[i]:i0[i+1]-1
+      if length(rg) == 1
+         push!(inds, "$(first(rg))")
+      else
+         rg = SVector(rg...)
+         push!(inds, "SA$rg")
+      end
+   end
+
+   code = "(; "
+   for (sym, ind) in zip(SYMS, inds)
+      code *= "$sym = v[$ind], "
+   end
+   code *= ")"
+
+   return quote
+      $(Meta.parse(code))
+   end
+end
+
+
+__zero(::Type{TX}) where {TX <: NamedTuple} =
+      reinterpret(TX, ntuple(_ -> Int8(0), sizeof(TX)))
+
+"""
+   grad_fd(f, x::NamedTuple, args...)
+
+`ForwardDiff` gradient of a function `f` with respect to the continuous
+variables stored in the NamedTuple `x`; returns a NamedTuple with
+the gradient values corresponding to the continuous variables in `x`.
+The `args...` are taken as constant paramteters during this differentiation.
+"""
+function grad_fd(f, x::NamedTuple, args...)
+   x_cts = _ctsnt(x)  # extract continuous variables into an SVector
+   _fvec = _v -> f(_replace(x, _svec2nt(_v, x_cts)), args...)
+   g = ForwardDiff.gradient(_fvec, _nt2svec(x_cts))
+   return _svec2nt(g, x_cts)  # return as NamedTuple
+end
+
+# function jac_fd(f, x::NamedTuple, ps, st)
+#    x_cts = _ctsnt(x)  # extract continuous variables into an SVector
+#    v = _nt2svec(x_cts)
+#    TV = typeof(v)
+#    _fvec = _v -> f(_replace(x, _svec2nt(_v, x_cts)), ps, st)[1]
+#    J = ForwardDiff.jacobian(_fvec, v)
+#    return [ _svec2nt(TV(rowJ), x_cts) for rowJ in eachrow(J) ]
+# end
+
+# ---------------------------------------
+# differentiation w.r.t. XStates
+
+_svec2nt(v::SVector, x::VState) = VState( _svec2nt(v, getfield(x, :x)) )
+
+_nt2svec(x::VState) = _nt2svec( getfield(x, :x) )
+
+"""
+   grad_fd(f, x::XState, args...)
+
+`ForwardDiff` gradient of a function `f` with respect to the continuous
+variables stored in the state `x`; returns a `VState` containing the
+gradient values. The `args...` are taken as constant parameters during
+this differentiation.
+"""
+function grad_fd(f, x::STATE, args...) where {STATE <: XState}
+   v0 = zero(vstate_type(x))
+   sv0 = _nt2svec(v0)
+   f_svec = sv -> f(x + _svec2nt(sv, v0), args...)
+   g_svec = ForwardDiff.gradient(f_svec, sv0)
+   return _svec2nt(g_svec, v0)
+end
+
+# function jac_fd(f, x::STATE, args...) where {STATE <: XState}
+#    x_nt = getfield(x, :x)
+#    v_nt = _ctsnt(x_nt)  # extract continuous variables into an SVector
+#    v = _nt2svec(v_nt)
+#    _fvec = _v -> f(STATE(_replace(x_nt, _svec2nt(_v, v_nt))), args...)
+#    g = ForwardDiff.jacobian(_fvec, _nt2svec(v_nt))
+#    return VState(_svec2nt(g, v_nt))  # return as NamedTuple
+# end

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -10,10 +10,9 @@ using StaticArrays
 
 export grad_fd
 
-_iscts(::Any) = false
-_iscts(::Type{T}) where {T <: AbstractFloat} = true
+# extend the continuity trait from states.jl to ForwardDiff duals, so
+# that nested differentiation sees dual-valued variables as continuous
 _iscts(::Type{Dual{T1, T2, T3}}) where {T1, T2, T3} = _iscts(T2)
-_iscts(T::Type{<: SArray}) = _iscts(eltype(T))
 
 
 """
@@ -29,31 +28,6 @@ a new NamedTuple with those variables.
    code = "(; "
    for (sym, T) in zip(SYMS, TT)
       if _iscts(T)
-         code *= "$sym = x.$sym,"
-      end
-   end
-   code *= ")"
-   return quote
-      $(Meta.parse(code))
-   end
-end
-
-"""
-   _replace(x::NamedTuple, v::NamedTuple)
-
-Assuming that `fieldnames(v)` is a subset of `fieldnames(x)`, this constructs
-a new `NamedTuple` `y` with the same fields as `x`, but with the values of `v` replacing
-the values of `x` for the fields that are present in `v`.
-"""
-@generated function _replace(x::NamedTuple, v::NamedTuple)
-   SYMSX = fieldnames(x)
-   SYMSV = fieldnames(v)
-
-   code = "(; "
-   for sym in SYMSX
-      if sym in SYMSV
-         code *= "$sym = v.$sym,"
-      else
          code *= "$sym = x.$sym,"
       end
    end
@@ -176,6 +150,9 @@ provides the data and the data type.
 end
 
 
+# NOTE: this cannot be folded into the `zero(::XState)` machinery in
+#       states.jl: defining `Base.zero(::Type{<:NamedTuple})` would be
+#       type piracy against Base.
 __zero(::Type{TX}) where {TX <: NamedTuple} =
       reinterpret(TX, ntuple(_ -> Int8(0), sizeof(TX)))
 
@@ -189,7 +166,7 @@ The `args...` are taken as constant paramteters during this differentiation.
 """
 function grad_fd(f, x::NamedTuple, args...)
    x_cts = _ctsnt(x)  # extract continuous variables into an SVector
-   _fvec = _v -> f(_replace(x, _svec2nt(_v, x_cts)), args...)
+   _fvec = _v -> f(merge(x, _svec2nt(_v, x_cts)), args...)
    g = ForwardDiff.gradient(_fvec, _nt2svec(x_cts))
    return _svec2nt(g, x_cts)  # return as NamedTuple
 end
@@ -198,7 +175,7 @@ end
 #    x_cts = _ctsnt(x)  # extract continuous variables into an SVector
 #    v = _nt2svec(x_cts)
 #    TV = typeof(v)
-#    _fvec = _v -> f(_replace(x, _svec2nt(_v, x_cts)), ps, st)[1]
+#    _fvec = _v -> f(merge(x, _svec2nt(_v, x_cts)), ps, st)[1]
 #    J = ForwardDiff.jacobian(_fvec, v)
 #    return [ _svec2nt(TV(rowJ), x_cts) for rowJ in eachrow(J) ]
 # end
@@ -230,7 +207,7 @@ end
 #    x_nt = getfield(x, :x)
 #    v_nt = _ctsnt(x_nt)  # extract continuous variables into an SVector
 #    v = _nt2svec(v_nt)
-#    _fvec = _v -> f(STATE(_replace(x_nt, _svec2nt(_v, v_nt))), args...)
+#    _fvec = _v -> f(STATE(merge(x_nt, _svec2nt(_v, v_nt))), args...)
 #    g = ForwardDiff.jacobian(_fvec, _nt2svec(v_nt))
 #    return VState(_svec2nt(g, v_nt))  # return as NamedTuple
 # end

--- a/src/states.jl
+++ b/src/states.jl
@@ -101,20 +101,27 @@ _symstt(::Type{<: XState{NamedTuple{SYMS, TT}}}) where {SYMS, TT} = SYMS, TT
 # which properties are continuous - this is important since certain operations 
 # act only on continuous variables but not on categorical variables. 
 
-const CTSTT = Union{AbstractFloat, 
+const CTSTT = Union{AbstractFloat,
                     Complex{<: AbstractFloat},
-                    SVector{N, <: AbstractFloat}, 
+                    SVector{N, <: AbstractFloat},
                     SVector{N, <: Complex}} where {N}
 
+# single source of truth for "is this a continuous variable"; used by
+# `_findcts` below as well as `_ctsnt` in differentiation.jl, where it is
+# extended with a method for ForwardDiff.Dual types.
+_iscts(::Any) = false
+_iscts(T::Type) = T <: CTSTT
+_iscts(T::Type{<: SArray}) = _iscts(eltype(T))
+
 """
-Find the indices of continuous properties, and return the 
+Find the indices of continuous properties, and return the
 indices as well as the symbols and types
 """
 _findcts(X::TX) where {TX <: XState} = _findcts(TX)
 
 @generated function _findcts(::Type{TX}) where {TX <: XState}
    SYMS, TT = _symstt(TX)
-   icts = findall(T -> T <: CTSTT, TT.types)
+   icts = findall(T -> _iscts(T), TT.types)
    quote 
       $(SVector(icts...))
    end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 @testset "DecoratedParticles.jl" begin
     include("test_states.jl")
     include("test_atomsbase.jl")
+    include("test_differentiation.jl")
 end

--- a/test/test_differentiation.jl
+++ b/test/test_differentiation.jl
@@ -1,0 +1,78 @@
+
+using DecoratedParticles, StaticArrays, Test, ForwardDiff
+using DecoratedParticles: PState, VState, grad_fd
+
+import DecoratedParticles as DP
+
+##
+
+@info("Testing differentiation tooling")
+@info(" ... preliminaries")
+
+rand_nt() = (q = randn(), r = randn(SVector{3, Float64}), z = rand(1:10))
+
+x = rand_nt()
+v_nt = DP._ctsnt(x)
+@test v_nt == (q = x.q, r = x.r)
+v = DP._nt2svec(v_nt)
+@test v == SVector{4, Float64}(x.q, x.r...)
+v_nt1 = DP._svec2nt(v, v_nt)
+@test v_nt1 == v_nt
+
+##
+
+@info(" ... grad_fd")
+
+module TestDiff
+   using StaticArrays, ForwardDiff
+   import DecoratedParticles: PState, VState
+
+   struct F{N, T}; W::SVector{N, T}; end
+
+   # random expression, but representative in terms of simplicity
+   (f::F)(x) = sum(x.r .* x.r) * x.q / (1 + f.W[x.z]^2)
+
+   # manual gradient, as NamedTuple
+   grad_man(f::F, x) = ( r2 = sum(x.r .* x.r); w = 1 / (1 + f.W[x.z]^2);
+                        (q = r2 * w, r = 2 * x.r * x.q * w, )  )
+
+   # gradient via ForwardDiff, component by component
+   function grad_1(f::F, x)
+      ∂q = ForwardDiff.derivative(q -> f((q=q,   r=x.r, z=x.z)), x.q)
+      ∂r = ForwardDiff.gradient(r -> f((q=x.q, r=r,   z=x.z)), x.r)
+      return (q = ∂q, r = ∂r)
+   end
+end
+
+f = TestDiff.F(@SVector randn(10))
+
+for ntest = 1:20
+   local x, x_dp
+   x = rand_nt()
+   x_dp = PState(; x...)
+   g_man = TestDiff.grad_man(f, x)
+   g_fd1 = TestDiff.grad_1(f, x)
+   g_nt = grad_fd(f, x)          # NamedTuple input -> NamedTuple output
+   g_dp = grad_fd(f, x_dp)       # PState input -> VState output
+   @test all(g_fd1[sym] ≈ g_man[sym] for sym in fieldnames(typeof(g_man)))
+   @test all(g_nt[sym] ≈ g_man[sym] for sym in fieldnames(typeof(g_man)))
+   @test g_dp isa VState
+   @test g_dp ≈ VState(g_man)
+end
+
+##
+
+@info(" ... allocation tests")
+
+N = 1000
+X = [ rand_nt() for _ in 1:N ]
+TG = typeof(grad_fd(f, X[1]))
+gY = Vector{TG}(undef, N)
+
+function count_alloc(f, gY, X)
+   gfun = x -> grad_fd(f, x)
+   map!(gfun, gY, X)
+   return @allocations map!(gfun, gY, X)
+end
+
+@test count_alloc(f, gY, X) <= 1

--- a/test/test_differentiation.jl
+++ b/test/test_differentiation.jl
@@ -62,6 +62,25 @@ end
 
 ##
 
+@info(" ... NamedTuple path vs PState path consistency")
+
+# the NamedTuple path (_ctsnt/_iscts) and the XState path
+# (vstate_type/_findcts) must agree on which fields are continuous,
+# including Complex and Dual fields
+using ForwardDiff: Dual
+
+nt_mixed = (q = randn(), r = randn(SVector{3, Float64}), z = rand(1:10),
+            c = randn(ComplexF64), d = Dual(randn(), 1.0))
+@test keys(DP._ctsnt(nt_mixed)) == DP._ctssyms(PState(; nt_mixed...))
+
+# Dual-valued fields survive the PState -> VState conversion
+# (needed for nested ForwardDiff through states)
+x_dual = PState(q = Dual(randn(), 1.0), r = randn(SVector{3, Float64}),
+                z = rand(1:10))
+@test haskey(getfield(VState(x_dual), :x), :q)
+
+##
+
 @info(" ... allocation tests")
 
 N = 1000


### PR DESCRIPTION
Moves the `DiffNT` functionality from `EquivariantTensors.jl`
(`src/transforms/diffnt.jl`) into DP as `src/differentiation.jl`, per the
ET restructuring plan: making DP states differentiable is core to DP's
purpose, so DP is the natural owner of this tooling.

**Commit 1 — the move:**
- `grad_fd(f, x, args...)` — ForwardDiff gradient w.r.t. the continuous
  variables of a `NamedTuple` or `XState` (returns NamedTuple / VState);
  exported.
- Internal helpers `_ctsnt`, `svector_type`, `_nt2svec`, `_svec2nt`,
  `__zero` ported (module wrapper and the `import DecoratedParticles:`
  indirection removed).
- New dep: ForwardDiff. Version bumped to 0.1.4.
- Tests adapted from ET's diffnt tests (correctness vs manual and
  componentwise ForwardDiff gradients, NamedTuple and PState paths,
  allocation check).

**Commit 2 — deduplication against existing DP machinery:**
- The ported `_iscts` predicate duplicated the `CTSTT`-based continuity
  notion in states.jl — and the two disagreed (Complex in `CTSTT` only,
  Dual in `_iscts` only), so the NamedTuple and XState paths of `grad_fd`
  differentiated different fields. Now there is a single `_iscts` trait in
  states.jl (defined via `CTSTT`, used by `_findcts`), extended with a
  Dual method in differentiation.jl.
- Deleted the ported `_replace`: for the subset case it is exactly
  `Base.merge`, type-stably (allocation test still passes).
- Behaviour changes (both arguably bug fixes):
  - Complex fields are now seen as continuous by `grad_fd(f, ::NamedTuple)`
    (consistent with the XState path; ForwardDiff errors loudly instead of
    silently differentiating around them).
  - Dual-valued fields now survive `PState -> VState` conversion, enabling
    nested ForwardDiff through states.
- New tests assert NT-path/XState-path agreement on field selection
  (incl. Complex + Dual) and Dual survival in `VState`.

Full suite passes (203 tests).

ET itself is unchanged for now; it will switch to importing this from DP
in a follow-up ET PR.